### PR TITLE
Fix DownloadFiles concurrency

### DIFF
--- a/ApiClient.UnitTests/ApiClientUnitTests.cs
+++ b/ApiClient.UnitTests/ApiClientUnitTests.cs
@@ -1484,4 +1484,50 @@ public class ApiClientUnitTests
         folderFilePath.Should().Be(@"\Recursion\A001 - ARCHITECTURAL - GRAPHIC SYMBOLS & ABBREVIATIONS.pdf");
         subfolderFilePath.Should().Be(@"\Recursion\1\A505 - OFFICE - ROOFING DETAILS.pdf");
     }
-}
+
+    [Fact]
+    public async Task DownloadFiles_Should_ReturnAllFiles_When_ExecutedInParallel()
+    {
+        // Arrange
+        const string clientId = "AFO4tyzt71HCkL73cn2tAUSRS0OSGaRY";
+        const string clientSecret = "wE3GFhuIsGJEi3d4";
+        const string accountId = "48a4d1eb-a370-42fe-89c9-4dd9e2ad9d41";
+        var httpClient = new HttpClient();
+
+        ApiClient sut = TwoLeggedApiClient
+            .Configure()
+            .WithClientId(clientId)
+            .AndClientSecret(clientSecret)
+            .ForAccount(accountId)
+            .WithOptions(options =>
+            {
+                options.HttpClient = httpClient;
+                options.DryRun = true;
+                options.MaxDegreeOfParallelism = 4;
+            })
+            .Create();
+
+        string rootDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(rootDirectory);
+
+        Folder rootFolder = FakeData.GetFakeFolder(sut);
+        rootFolder.Name = "Root";
+
+        List<File> files = new();
+        for (var i = 0; i < 20; i++)
+        {
+            File file = FakeData.GetFakeFile(rootFolder);
+            file.Name = $"file_{i}.txt";
+            files.Add(file);
+        }
+
+        // Act
+        List<FileInfo> fileInfos = await sut.DownloadFiles(files, rootDirectory);
+
+        // Assert
+        fileInfos.Should().HaveCount(files.Count);
+        fileInfos.Select(f => f.FullName).Should().OnlyHaveUniqueItems();
+        files.All(f => f.FileInfo != null).Should().BeTrue();
+
+        Directory.Delete(rootDirectory, true);
+    }}

--- a/ApiClient/ApiClient.cs
+++ b/ApiClient/ApiClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Collections.Concurrent;
 using ACC.ApiClient.Entities;
 using ACC.ApiClient.RestApiResponses;
 using Newtonsoft.Json;
@@ -489,7 +490,7 @@ public class ApiClient : IApiClient
     public async Task<List<FileInfo>> DownloadFiles(
         IEnumerable<File> fileList, string rootDirectory, CancellationToken ct = default)
     {
-        List<FileInfo> fileInfoList = new();
+        ConcurrentBag<FileInfo> fileInfoBag = new();
 
         var parallelOptions = new ParallelOptions
         {
@@ -500,10 +501,10 @@ public class ApiClient : IApiClient
         await Parallel.ForEachAsync(fileList, parallelOptions, async (file, ctx) =>
         {
             FileInfo fileInfo = await DownloadFile(file, rootDirectory, ctx);
-            fileInfoList.Add(fileInfo);
+            fileInfoBag.Add(fileInfo);
         });
 
-        return fileInfoList;
+        return fileInfoBag.ToList();
     }
 
     private Folder MapFolderFromFolderContentsResponseData(string projectId, string parentFolderId,


### PR DESCRIPTION
## Summary
- use `ConcurrentBag<FileInfo>` for thread-safe collection in `DownloadFiles`
- convert bag to list before returning
- add a regression test ensuring parallel `DownloadFiles` returns all files

## Testing
- `dotnet test ApiClient.UnitTests/ApiClient.UnitTests.csproj --verbosity minimal` *(fails: FileNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_686da599ee7883279ee177a3c6982571