### PR TITLE
Fix logging level for Error() and add unit test

### DIFF
--- a/Library.Logger.UnitTests/Library.Logger.UnitTests.csproj
+++ b/Library.Logger.UnitTests/Library.Logger.UnitTests.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="FluentAssertions" Version="6.6.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
         <PackageReference Include="NSubstitute" Version="4.3.0"/>
+        <PackageReference Include="NLog" Version="4.7.15"/>
         <PackageReference Include="xunit" Version="2.4.1"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Library.Logger.UnitTests/NLogLoggerUnitTests.cs
+++ b/Library.Logger.UnitTests/NLogLoggerUnitTests.cs
@@ -1,6 +1,8 @@
 using System;
 using FluentAssertions;
 using NSubstitute;
+using NLog;
+using NLog.Targets;
 using Xunit;
 
 namespace Library.Logger.UnitTests;
@@ -342,6 +344,26 @@ public class NLogLoggerUnitTests
         // Assert
         act.Should().NotThrow();
         _sutMock.Received(1).Error(ex, message);
+    }
+
+    [Fact]
+    public void Error_Should_LogAtErrorLevel()
+    {
+        // Arrange
+        var memoryTarget = new MemoryTarget();
+        var config = LogManager.Configuration;
+        config.AddRule(NLog.LogLevel.Trace, NLog.LogLevel.Fatal, memoryTarget);
+        LogManager.ReconfigExistingLoggers();
+
+        var guid = Guid.NewGuid();
+        string message = $"Test:{guid}";
+
+        // Act
+        _sut.Error(message);
+
+        // Assert
+        memoryTarget.Logs.Should().ContainSingle();
+        memoryTarget.Logs[0].Should().Contain("|Error|");
     }
 
     [Fact]

--- a/Library.Logger/NLogLogger.cs
+++ b/Library.Logger/NLogLogger.cs
@@ -64,7 +64,7 @@ public class NLogLogger : ILogger
 
     public virtual void Error(string message)
     {
-        Log.Warn(message);
+        Log.Error(message);
     }
 
     public virtual void Error(Exception ex, string message)


### PR DESCRIPTION
## Summary
- ensure `NLogLogger.Error(string)` calls `Log.Error`
- add memory target test verifying error level
- reference NLog package for unit tests

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686da597664c83278a045b13664dd04b